### PR TITLE
Load custom CSS after loading fontawesome.

### DIFF
--- a/designs/index.html
+++ b/designs/index.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Argent Bank - Home Page</title>
-    <link rel="stylesheet" href="./css/main.css" />
     <link
       rel="stylesheet"
       href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
     />
+    <link rel="stylesheet" href="./css/main.css" />
   </head>
   <body>
     <nav class="main-nav">

--- a/designs/sign-in.html
+++ b/designs/sign-in.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Argent Bank - Home Page</title>
-    <link rel="stylesheet" href="./css/main.css" />
     <link
       rel="stylesheet"
       href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
     />
+    <link rel="stylesheet" href="./css/main.css" />
   </head>
   <body>
     <nav class="main-nav">

--- a/designs/user.html
+++ b/designs/user.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Argent Bank - Home Page</title>
-    <link rel="stylesheet" href="./css/main.css" />
     <link
       rel="stylesheet"
       href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
     />
+    <link rel="stylesheet" href="./css/main.css" />
   </head>
   <body>
     <nav class="main-nav">


### PR DESCRIPTION
This prevents the vendor CSS from overriding the custom CSS.
This was notably a problem for the size of the icon on the sign-in page
but is good practice anyway so all three pages have been changed.