### PR TITLE
fix: use volta to fix node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   },
   "devDependencies": {
     "nodemon": "^2.0.4"
+  },
+  "volta": {
+    "node": "12.22.12"
   }
 }


### PR DESCRIPTION
"Étant donné les nombreux problèmes rencontrés par les étudiants lors de la configuration du projet en raison des différentes versions de Node.js requises, j'ai décidé personnellement d'utiliser [Volta](https://volta.sh/) pour simplifier ce processus.

Je propose également de mettre à jour le cours correspondant afin d'encourager l'utilisation de Volta, qui est plus convivial que NVM pour gérer les versions de Node.js."